### PR TITLE
Fix pytest import path for spark package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root (the directory containing the `spark` package) is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- ensure the repository root is added to sys.path during test collection so the spark package can be imported

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0c764898832a9d4172788d8a0135