### PR TITLE
Fix demopack decoding aggregation and router weights

### DIFF
--- a/spark/hash_router.py
+++ b/spark/hash_router.py
@@ -18,9 +18,10 @@ def route_tokens(
     router_scores = torch.randn(batch, seq_len, num_neurons, device=hidden.device)
     topk = torch.topk(router_scores, num_active, dim=-1)
     indices = topk.indices
-    mask = torch.zeros_like(router_scores)
-    mask.scatter_(dim=-1, index=indices, src=torch.ones_like(indices, dtype=mask.dtype))
-    compressed = torch.einsum("bsh,bsnh->bsn", hidden, mask)
+    # Convert router scores into normalized dispatch weights for the selected
+    # neurons and broadcast the token representations to each active slot.
+    weights = torch.softmax(topk.values, dim=-1)
+    compressed = hidden.unsqueeze(-2) * weights.unsqueeze(-1)
     return indices, compressed
 
 


### PR DESCRIPTION
## Summary
- aggregate decoded demopack tiles so each instruction contributes the expected number of output rows
- normalize router scores into dispatch weights and broadcast token states instead of relying on an invalid einsum

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0db402cc832aacb1acb0945010a0