### PR TITLE
Integrate attention routing and cache subsystems

### DIFF
--- a/spark/hash_router.py
+++ b/spark/hash_router.py
@@ -13,16 +13,25 @@ def route_tokens(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Select a sparse subset of neurons per token using random hashes."""
 
+    indices, _, compressed = route_tokens_with_metadata(hidden, sparsity, num_neurons)
+    return indices, compressed
+
+
+def route_tokens_with_metadata(
+    hidden: torch.Tensor,
+    sparsity: float,
+    num_neurons: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Hash-based routing that also returns dispatch weights for analysis."""
+
     batch, seq_len, _ = hidden.shape
     num_active = max(1, int(num_neurons * sparsity))
     router_scores = torch.randn(batch, seq_len, num_neurons, device=hidden.device)
     topk = torch.topk(router_scores, num_active, dim=-1)
     indices = topk.indices
-    # Convert router scores into normalized dispatch weights for the selected
-    # neurons and broadcast the token representations to each active slot.
     weights = torch.softmax(topk.values, dim=-1)
     compressed = hidden.unsqueeze(-2) * weights.unsqueeze(-1)
-    return indices, compressed
+    return indices, weights, compressed
 
 
-__all__ = ["route_tokens"]
+__all__ = ["route_tokens", "route_tokens_with_metadata"]

--- a/spark/procedural_model.py
+++ b/spark/procedural_model.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
-from .attention import AttentionBasisSynthesizer, AtomConfig
+from .attention import AttentionBasisSynthesizer, AtomConfig, AttentionPatch
 from .demopack import CodebookSpec, DemopackCodebook, DemopackDecoder, build_random_instructions
+from .hash_router import route_tokens_with_metadata
 from .kv_patcher import KVCachePatcher
 from .layer_generator import GeneratorConfig, LayerGenerator, apply_lora_delta
 from .opcode_vm import Instruction, OpcodeVM
@@ -20,6 +21,11 @@ class ProceduralModelConfig:
     vocab_size: int
     codebook_spec: CodebookSpec
     generator_config: GeneratorConfig
+    attention_enabled: bool = True
+    routing_enabled: bool = True
+    kv_cache_enabled: bool = True
+    router_sparsity: float = 0.25
+    router_num_neurons: int = 64
 
 
 class ProceduralLanguageModel(torch.nn.Module):
@@ -44,6 +50,11 @@ class ProceduralLanguageModel(torch.nn.Module):
         )
         self.generator = LayerGenerator(config.generator_config, metadata_dim=8)
         self.lm_head = torch.nn.Linear(num_tiles * tile_rows, config.vocab_size)
+        self.token_proj = torch.nn.Linear(config.input_dim, config.hidden_dim)
+        self.query_proj = torch.nn.Linear(config.hidden_dim, config.hidden_dim)
+        self.key_proj = torch.nn.Linear(config.hidden_dim, config.hidden_dim)
+        self.value_proj = torch.nn.Linear(config.hidden_dim, config.hidden_dim)
+        self.attn_output_proj = torch.nn.Linear(config.hidden_dim, config.input_dim)
         atom_cfgs = [
             AtomConfig(name="sin", frequency=freq) for freq in (1.0, 2.0, 4.0)
         ] + [
@@ -52,9 +63,75 @@ class ProceduralLanguageModel(torch.nn.Module):
         self.attention = AttentionBasisSynthesizer(atom_cfgs, max_length=1024)
         self.kv_patcher = KVCachePatcher()
         self.vm = OpcodeVM()
+        self.latest_routing_metadata: List[Optional[Dict[str, torch.Tensor]]] = []
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        hidden = self.decoder(inputs)
+        if inputs.ndim == 2:
+            inputs = inputs.unsqueeze(1)
+        elif inputs.ndim != 3:
+            raise ValueError("Inputs must be rank-2 or rank-3 tensor")
+
+        _, seq_len, _ = inputs.shape
+        device = inputs.device
+
+        tokens = self.token_proj(inputs)
+        queries = self.query_proj(tokens)
+        keys = self.key_proj(tokens)
+        values = self.value_proj(tokens)
+
+        decoder_inputs: List[torch.Tensor] = []
+        routing_metadata: List[Optional[Dict[str, torch.Tensor]]] = []
+
+        for step in range(seq_len):
+            query = queries[:, step : step + 1, :]
+            if self.config.kv_cache_enabled:
+                segment_id = step
+                self.kv_patcher.mark(segment_id)
+                try:
+                    cached_keys, cached_values = self.kv_patcher.gather([segment_id])
+                except KeyError:
+                    cached_keys = keys[:, : step + 1, :]
+                    cached_values = values[:, : step + 1, :]
+                else:
+                    if cached_keys.size(1) < step + 1:
+                        new_keys = keys[:, cached_keys.size(1) : step + 1, :]
+                        new_values = values[:, cached_keys.size(1) : step + 1, :]
+                        cached_keys = torch.cat([cached_keys, new_keys], dim=1)
+                        cached_values = torch.cat([cached_values, new_values], dim=1)
+                self.kv_patcher.update(segment_id, cached_keys, cached_values)
+            else:
+                cached_keys = keys[:, : step + 1, :]
+                cached_values = values[:, : step + 1, :]
+
+            if self.config.attention_enabled:
+                patch = self._build_attention_patch(query.size(1), device)
+                attn_out = self.attention.apply_attention(
+                    patch, query, cached_keys, cached_values
+                )
+            else:
+                attn_out = query
+
+            if self.config.routing_enabled:
+                sparse, dense, metadata = self._compile_routing_metadata(attn_out)
+                combined = sparse.sum(dim=-2)
+                fallback = dense.squeeze(1)
+                combined = combined.squeeze(1)
+                combined = combined + (fallback - fallback.detach())
+                routing_metadata.append(metadata)
+            else:
+                combined = attn_out.squeeze(1)
+                routing_metadata.append(None)
+
+            decoder_inputs.append(self.attn_output_proj(combined))
+
+        if self.config.kv_cache_enabled:
+            self.kv_patcher.sweep()
+
+        self.latest_routing_metadata = routing_metadata
+
+        stacked = torch.stack(decoder_inputs, dim=1)
+        decoder_input = stacked.mean(dim=1)
+        hidden = self.decoder(decoder_input)
         logits = self.lm_head(hidden)
         return logits
 
@@ -67,6 +144,26 @@ class ProceduralLanguageModel(torch.nn.Module):
     def reason(self, instructions: List[Instruction]) -> List[str]:
         state = self.vm.execute(instructions)
         return state.log
+
+    def _build_attention_patch(self, seq_len: int, device: torch.device) -> AttentionPatch:
+        atom_indices = torch.arange(len(self.attention.atoms), device=device, dtype=torch.long)
+        gains = torch.ones(atom_indices.size(0), device=device, dtype=torch.float32)
+        shifts = torch.zeros_like(atom_indices)
+        window = torch.ones(seq_len, device=device, dtype=torch.float32)
+        return AttentionPatch(atom_indices=atom_indices, gains=gains, shifts=shifts, window=window)
+
+    def _compile_routing_metadata(
+        self, hidden: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, torch.Tensor]]:
+        sparsity = self.config.router_sparsity
+        num_neurons = self.config.router_num_neurons
+        indices, weights, compressed = route_tokens_with_metadata(
+            hidden,
+            sparsity=sparsity,
+            num_neurons=num_neurons,
+        )
+        metadata: Dict[str, torch.Tensor] = {"indices": indices, "weights": weights}
+        return compressed, hidden, metadata
 
 
 __all__ = ["ProceduralModelConfig", "ProceduralLanguageModel"]

--- a/tests/test_hash_router.py
+++ b/tests/test_hash_router.py
@@ -2,7 +2,7 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from spark.hash_router import route_tokens
+from spark.hash_router import route_tokens, route_tokens_with_metadata
 
 
 def test_route_tokens_shape():
@@ -10,3 +10,13 @@ def test_route_tokens_shape():
     indices, compressed = route_tokens(hidden, sparsity=0.1, num_neurons=32)
     assert indices.shape[:2] == (2, 4)
     assert compressed.shape[:2] == (2, 4)
+
+
+def test_route_tokens_with_metadata():
+    hidden = torch.randn(2, 4, 16)
+    indices, weights, compressed = route_tokens_with_metadata(
+        hidden, sparsity=0.25, num_neurons=8
+    )
+    assert indices.shape == (2, 4, 2)
+    assert weights.shape == (2, 4, 2)
+    assert compressed.shape == (2, 4, 2, 16)


### PR DESCRIPTION
## Summary
- add a metadata-returning hash router helper while keeping the existing API intact
- extend the procedural language model with attention, routing, and KV cache hooks plus new config toggles
- capture routing metadata and project attention outputs through the demopack decoder before the LM head

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db1071c3e0832abc0dd3545355ea85