### PR TITLE
Add deterministic data pipeline and instruction serialization

### DIFF
--- a/spark/data/__init__.py
+++ b/spark/data/__init__.py
@@ -1,0 +1,22 @@
+"""Data utilities for SPARK procedural experiments."""
+from .dataset import ProceduralDataset, ProceduralDatasetConfig
+from .instructions import InstructionSeedSet, materialize_instructions
+from .statistics import (
+    METADATA_DIM,
+    DatasetStatistics,
+    deserialize_metadata_tensor,
+    metadata_from_tokens,
+    serialize_metadata_tensor,
+)
+
+__all__ = [
+    "METADATA_DIM",
+    "DatasetStatistics",
+    "ProceduralDataset",
+    "ProceduralDatasetConfig",
+    "InstructionSeedSet",
+    "materialize_instructions",
+    "metadata_from_tokens",
+    "serialize_metadata_tensor",
+    "deserialize_metadata_tensor",
+]

--- a/spark/data/dataset.py
+++ b/spark/data/dataset.py
@@ -1,0 +1,72 @@
+"""Synthetic data module emitting token, metadata and target tuples."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Optional, Tuple
+
+import torch
+
+from .statistics import DatasetStatistics, metadata_from_tokens
+
+
+@dataclass
+class ProceduralDatasetConfig:
+    vocab_size: int
+    sequence_length: int
+    batch_size: int
+    num_batches: Optional[int] = None
+    seed: int = 0
+    device: Optional[torch.device] = None
+
+
+class ProceduralDataset:
+    """Generates reproducible batches of tokens and metadata."""
+
+    def __init__(self, config: ProceduralDatasetConfig, preview_batches: int = 8) -> None:
+        self.config = config
+        self._device = config.device or torch.device("cpu")
+        self._seed = config.seed
+        self._preview_batches = max(preview_batches, 1)
+        self._statistics = self._bootstrap_statistics()
+
+    @property
+    def statistics(self) -> DatasetStatistics:
+        return self._statistics
+
+    def iter_batches(self, num_batches: Optional[int] = None) -> Iterator[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        limit = num_batches if num_batches is not None else self.config.num_batches
+        produced = 0
+        generator = torch.Generator(device=self._device).manual_seed(self._seed)
+        while limit is None or produced < limit:
+            tokens = torch.randint(
+                0,
+                self.config.vocab_size,
+                (self.config.batch_size, self.config.sequence_length),
+                generator=generator,
+                dtype=torch.int64,
+                device=self._device,
+            )
+            metadata = metadata_from_tokens(tokens, self.config.vocab_size)
+            targets = torch.roll(tokens, shifts=-1, dims=1)
+            produced += 1
+            yield tokens, metadata, targets
+
+    def _bootstrap_statistics(self) -> DatasetStatistics:
+        preview = []
+        generator = torch.Generator(device=self._device).manual_seed(self._seed)
+        for _ in range(self._preview_batches):
+            tokens = torch.randint(
+                0,
+                self.config.vocab_size,
+                (self.config.batch_size, self.config.sequence_length),
+                generator=generator,
+                dtype=torch.int64,
+            )
+            preview.append(tokens.cpu())
+        if not preview:
+            raise RuntimeError("Failed to materialize preview batches for statistics")
+        sample_tokens = torch.cat(preview, dim=0)
+        return DatasetStatistics.from_tokens(sample_tokens, self.config.vocab_size)
+
+
+__all__ = ["ProceduralDataset", "ProceduralDatasetConfig"]

--- a/spark/data/instructions.py
+++ b/spark/data/instructions.py
@@ -1,0 +1,83 @@
+"""Instruction seed management for deterministic decoding."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import torch
+
+from spark.demopack import DecodeInstruction
+
+from .statistics import DatasetStatistics
+
+
+@dataclass
+class InstructionSeedSet:
+    """Container tracking per-layer instruction seeds."""
+
+    statistics: DatasetStatistics
+    seeds: List[int] = field(default_factory=list)
+    embedding: Optional[torch.Tensor] = None
+
+    @classmethod
+    def from_statistics(
+        cls,
+        statistics: DatasetStatistics,
+        num_layers: int,
+        embedding: Optional[torch.Tensor] = None,
+    ) -> "InstructionSeedSet":
+        seed_list = [statistics.seed_for_layer(i, embedding) for i in range(num_layers)]
+        return cls(statistics=statistics, seeds=seed_list, embedding=embedding)
+
+    def ensure_length(self, num_layers: int) -> None:
+        while len(self.seeds) < num_layers:
+            layer_index = len(self.seeds)
+            self.seeds.append(self.statistics.seed_for_layer(layer_index, self.embedding))
+
+    def to_dict(self) -> dict:
+        return {
+            "statistics": self.statistics.to_dict(),
+            "seeds": list(self.seeds),
+            "embedding": None
+            if self.embedding is None
+            else self.embedding.detach().cpu().tolist(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "InstructionSeedSet":
+        statistics = DatasetStatistics.from_dict(payload["statistics"])
+        embedding = payload.get("embedding")
+        tensor_embed = None
+        if embedding is not None:
+            tensor_embed = torch.tensor(embedding, dtype=torch.float32)
+        return cls(statistics=statistics, seeds=list(payload.get("seeds", [])), embedding=tensor_embed)
+
+
+def materialize_instructions(
+    seed_set: InstructionSeedSet,
+    num_layers: int,
+    tile_shape: Tuple[int, int],
+    codebook_size: int,
+    device: Optional[torch.device] = None,
+) -> List[DecodeInstruction]:
+    """Decode deterministic instruction tensors from ``seed_set``."""
+
+    seed_set.ensure_length(num_layers)
+    rows, cols = tile_shape
+    instructions: List[DecodeInstruction] = []
+    for layer_index in range(num_layers):
+        seed = seed_set.seeds[layer_index]
+        generator = torch.Generator(device=device).manual_seed(int(seed))
+        indices = torch.randint(
+            0,
+            codebook_size,
+            (rows, cols),
+            dtype=torch.int32,
+            generator=generator,
+            device=device,
+        )
+        instructions.append(DecodeInstruction(codeword_indices=indices, scale=1.0))
+    return instructions
+
+
+__all__ = ["InstructionSeedSet", "materialize_instructions"]

--- a/spark/data/statistics.py
+++ b/spark/data/statistics.py
@@ -1,0 +1,160 @@
+"""Dataset statistics and metadata utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+
+METADATA_DIM: int = 8
+
+
+def _normalize_divisor(value: int) -> float:
+    return float(value) if value else 1.0
+
+
+def metadata_from_tokens(tokens: torch.Tensor, vocab_size: int) -> torch.Tensor:
+    """Compute metadata features for each sequence in ``tokens``.
+
+    The returned tensor has ``METADATA_DIM`` features capturing distributional
+    properties of the batch that are useful for conditioning the
+    :class:`~spark.layer_generator.LayerGenerator` hypernetwork.
+    """
+
+    if tokens.ndim != 2:
+        raise ValueError("Expected rank-2 token tensor with shape (batch, seq_len)")
+    tokens_f = tokens.to(dtype=torch.float32)
+    batch, seq_len = tokens_f.shape
+    if seq_len == 0:
+        raise ValueError("Cannot compute metadata for empty sequences")
+    vmax = max(vocab_size - 1, 1)
+    mean = tokens_f.mean(dim=1)
+    std = tokens_f.std(dim=1, unbiased=False)
+    min_vals, _ = tokens_f.min(dim=1)
+    max_vals, _ = tokens_f.max(dim=1)
+    first_token = tokens_f[:, 0]
+    last_token = tokens_f[:, -1]
+    length = torch.full((batch,), float(seq_len), dtype=torch.float32, device=tokens_f.device)
+    unique_counts = torch.tensor(
+        [float(torch.unique(tokens[i]).numel()) for i in range(batch)],
+        dtype=torch.float32,
+        device=tokens_f.device,
+    )
+    metadata = torch.stack(
+        [
+            mean / vmax,
+            std / _normalize_divisor(vocab_size),
+            min_vals / vmax,
+            max_vals / vmax,
+            unique_counts / _normalize_divisor(vocab_size),
+            first_token / vmax,
+            last_token / vmax,
+            length / float(seq_len),
+        ],
+        dim=1,
+    )
+    return metadata
+
+
+@dataclass
+class DatasetStatistics:
+    """Summary statistics required for deterministic instruction seeds."""
+
+    vocab_size: int
+    sequence_length: int
+    summary: torch.Tensor
+
+    @classmethod
+    def from_tokens(cls, tokens: torch.Tensor, vocab_size: int) -> "DatasetStatistics":
+        if tokens.ndim != 2:
+            raise ValueError("Expected rank-2 tensor with shape (num_samples, seq_len)")
+        metadata = metadata_from_tokens(tokens, vocab_size)
+        summary = metadata.mean(dim=0)
+        return cls(vocab_size=vocab_size, sequence_length=tokens.size(1), summary=summary)
+
+    @classmethod
+    def synthetic(cls, vocab_size: int, sequence_length: int) -> "DatasetStatistics":
+        base = torch.arange(sequence_length, dtype=torch.int64)
+        samples = base.repeat(vocab_size, 1) % max(vocab_size, 1)
+        return cls.from_tokens(samples, vocab_size)
+
+    def to_metadata_tensor(self) -> torch.Tensor:
+        tensor = self.summary.detach().clone()
+        if tensor.numel() != METADATA_DIM:
+            raise ValueError(
+                f"Summary metadata must contain {METADATA_DIM} values, got {tensor.numel()}"
+            )
+        return tensor
+
+    def seed_for_layer(self, layer_index: int, embedding: Optional[torch.Tensor] = None) -> int:
+        """Derive a reproducible RNG seed for ``layer_index``.
+
+        The seed deterministically combines dataset statistics with an optional
+        embedding vector. This keeps procedural weight decoding reproducible
+        across training and inference runs.
+        """
+
+        if layer_index < 0:
+            raise ValueError("Layer index must be non-negative")
+        stats_vector = torch.cat(
+            [
+                torch.tensor(
+                    [float(self.vocab_size), float(self.sequence_length)],
+                    dtype=torch.float32,
+                )
+                / _normalize_divisor(self.vocab_size),
+                self.to_metadata_tensor(),
+            ]
+        )
+        if embedding is not None:
+            embed_vec = embedding.to(dtype=torch.float32).flatten()
+            stats_vector = torch.cat([stats_vector, embed_vec])
+        hash_value = torch.sum(stats_vector * (layer_index + 1) * 1000.0).item()
+        seed = int(abs(hash_value)) % (2**31 - 1)
+        if seed == 0:
+            seed = layer_index + 1
+        return seed
+
+    def to_dict(self) -> dict:
+        return {
+            "vocab_size": self.vocab_size,
+            "sequence_length": self.sequence_length,
+            "summary": self.summary.detach().cpu().tolist(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "DatasetStatistics":
+        summary = torch.tensor(payload["summary"], dtype=torch.float32)
+        return cls(
+            vocab_size=int(payload["vocab_size"]),
+            sequence_length=int(payload["sequence_length"]),
+            summary=summary,
+        )
+
+
+def serialize_metadata_tensor(metadata: torch.Tensor) -> dict:
+    """Serialize a metadata tensor to a portable dictionary."""
+
+    return {
+        "shape": list(metadata.shape),
+        "values": metadata.detach().cpu().tolist(),
+    }
+
+
+def deserialize_metadata_tensor(payload: dict, device: Optional[torch.device] = None) -> torch.Tensor:
+    """Inverse of :func:`serialize_metadata_tensor`."""
+
+    tensor = torch.tensor(payload["values"], dtype=torch.float32, device=device)
+    shape: Tuple[int, ...] = tuple(payload["shape"])
+    if int(torch.tensor(shape).prod().item()) != tensor.numel():
+        raise ValueError("Serialized metadata has inconsistent shape")
+    return tensor.view(*shape)
+
+
+__all__ = [
+    "DatasetStatistics",
+    "METADATA_DIM",
+    "metadata_from_tokens",
+    "serialize_metadata_tensor",
+    "deserialize_metadata_tensor",
+]

--- a/spark/demopack.py
+++ b/spark/demopack.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import torch
 
@@ -132,10 +132,57 @@ def build_random_instructions(
     return instructions
 
 
+def serialize_instruction(instruction: DecodeInstruction) -> dict:
+    """Serialize a single :class:`DecodeInstruction` into a portable dict."""
+
+    payload = {
+        "codeword_indices": instruction.codeword_indices.detach().cpu().tolist(),
+        "scale": float(instruction.scale),
+        "rotation": None,
+    }
+    if instruction.rotation is not None:
+        payload["rotation"] = instruction.rotation.detach().cpu().tolist()
+    return payload
+
+
+def deserialize_instruction(payload: dict, device: Optional[torch.device] = None) -> DecodeInstruction:
+    """Reconstruct a :class:`DecodeInstruction` from serialized data."""
+
+    indices = torch.tensor(payload["codeword_indices"], dtype=torch.int32, device=device)
+    rotation = payload.get("rotation")
+    rotation_tensor = None
+    if rotation is not None:
+        rotation_tensor = torch.tensor(rotation, dtype=torch.float32, device=device)
+    return DecodeInstruction(
+        codeword_indices=indices,
+        scale=float(payload.get("scale", 1.0)),
+        rotation=rotation_tensor,
+    )
+
+
+def serialize_instruction_set(instructions: Sequence[DecodeInstruction]) -> List[dict]:
+    """Serialize a sequence of instructions for persistence."""
+
+    return [serialize_instruction(inst) for inst in instructions]
+
+
+def deserialize_instruction_set(
+    payload: Sequence[dict],
+    device: Optional[torch.device] = None,
+) -> List[DecodeInstruction]:
+    """Inverse of :func:`serialize_instruction_set`."""
+
+    return [deserialize_instruction(item, device=device) for item in payload]
+
+
 __all__ = [
     "CodebookSpec",
     "DemopackCodebook",
     "DemopackDecoder",
     "DecodeInstruction",
     "build_random_instructions",
+    "serialize_instruction",
+    "deserialize_instruction",
+    "serialize_instruction_set",
+    "deserialize_instruction_set",
 ]

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -1,0 +1,87 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from spark.data import (
+    METADATA_DIM,
+    DatasetStatistics,
+    InstructionSeedSet,
+    ProceduralDataset,
+    ProceduralDatasetConfig,
+    deserialize_metadata_tensor,
+    materialize_instructions,
+    serialize_metadata_tensor,
+)
+from spark.demopack import deserialize_instruction_set, serialize_instruction_set
+
+
+def test_procedural_dataset_emits_expected_shapes():
+    config = ProceduralDatasetConfig(
+        vocab_size=32,
+        sequence_length=12,
+        batch_size=4,
+        num_batches=2,
+        seed=123,
+    )
+    dataset = ProceduralDataset(config)
+    batch = next(dataset.iter_batches(num_batches=1))
+    tokens, metadata, targets = batch
+    assert tokens.shape == (4, 12)
+    assert metadata.shape == (4, METADATA_DIM)
+    assert targets.shape == (4, 12)
+    dataset_again = ProceduralDataset(config)
+    tokens_b, metadata_b, targets_b = next(dataset_again.iter_batches(num_batches=1))
+    assert torch.equal(tokens, tokens_b)
+    assert torch.allclose(metadata, metadata_b)
+    assert torch.equal(targets, targets_b)
+
+
+def test_instruction_seed_set_materialization_roundtrip():
+    config = ProceduralDatasetConfig(vocab_size=48, sequence_length=6, batch_size=2, seed=7)
+    dataset = ProceduralDataset(config)
+    stats = dataset.statistics
+    seed_set = InstructionSeedSet.from_statistics(stats, num_layers=3)
+    payload = seed_set.to_dict()
+    restored = InstructionSeedSet.from_dict(payload)
+    instructions = materialize_instructions(
+        seed_set=restored,
+        num_layers=3,
+        tile_shape=(2, config.sequence_length),
+        codebook_size=config.vocab_size,
+    )
+    instructions_again = materialize_instructions(
+        seed_set=restored,
+        num_layers=3,
+        tile_shape=(2, config.sequence_length),
+        codebook_size=config.vocab_size,
+    )
+    for inst_a, inst_b in zip(instructions, instructions_again):
+        assert torch.equal(inst_a.codeword_indices, inst_b.codeword_indices)
+        assert inst_a.scale == pytest.approx(inst_b.scale)
+
+
+def test_instruction_and_metadata_serialization():
+    config = ProceduralDatasetConfig(vocab_size=16, sequence_length=8, batch_size=3, seed=99)
+    dataset = ProceduralDataset(config)
+    tokens, metadata, _ = next(dataset.iter_batches(num_batches=1))
+    seed_set = InstructionSeedSet.from_statistics(dataset.statistics, num_layers=2)
+    instructions = materialize_instructions(
+        seed_set=seed_set,
+        num_layers=2,
+        tile_shape=(2, config.sequence_length),
+        codebook_size=config.vocab_size,
+    )
+    serialized_instructions = serialize_instruction_set(instructions)
+    restored_instructions = deserialize_instruction_set(serialized_instructions)
+    for inst_original, inst_restored in zip(instructions, restored_instructions):
+        assert torch.equal(inst_original.codeword_indices, inst_restored.codeword_indices)
+        assert inst_original.scale == pytest.approx(inst_restored.scale)
+        if inst_original.rotation is None:
+            assert inst_restored.rotation is None
+    serialized_metadata = serialize_metadata_tensor(metadata)
+    restored_metadata = deserialize_metadata_tensor(serialized_metadata)
+    assert restored_metadata.shape == metadata.shape
+    assert torch.allclose(restored_metadata, metadata)
+    stats_payload = dataset.statistics.to_dict()
+    restored_stats = DatasetStatistics.from_dict(stats_payload)
+    assert torch.allclose(restored_stats.to_metadata_tensor(), dataset.statistics.to_metadata_tensor())

--- a/tests/test_demopack.py
+++ b/tests/test_demopack.py
@@ -2,13 +2,21 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from spark.demopack import CodebookSpec, DemopackCodebook, DemopackDecoder, build_random_instructions
+from spark.data import DatasetStatistics, InstructionSeedSet, materialize_instructions
+from spark.demopack import CodebookSpec, DemopackCodebook, DemopackDecoder
 
 
 def test_demopack_decode_matches_linear():
     spec = CodebookSpec(num_codewords=16, embedding_dim=8)
     codebook = DemopackCodebook(spec)
-    instructions = build_random_instructions(4, (4, 8), spec.num_codewords)
+    stats = DatasetStatistics.synthetic(vocab_size=spec.num_codewords, sequence_length=8)
+    seed_set = InstructionSeedSet.from_statistics(stats, num_layers=4)
+    instructions = materialize_instructions(
+        seed_set=seed_set,
+        num_layers=4,
+        tile_shape=(4, 8),
+        codebook_size=spec.num_codewords,
+    )
     layer = DemopackDecoder(codebook, out_features=16, in_features=8, instructions=instructions)
     x = torch.randn(2, 8)
     out = layer(x)


### PR DESCRIPTION
## Summary
- add a spark.data module that provides reproducible token/metadata batches and dataset statistics
- derive deterministic Demopack instructions from persisted seed sets and expose serialization helpers
- update the procedural model and tests to rely on the new data utilities for reproducible runs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db107d4590832a8506e923a394ae4d