### PR TITLE
Restore procedural routing integration with deterministic decoder seeds

### DIFF
--- a/spark/data/__init__.py
+++ b/spark/data/__init__.py
@@ -1,0 +1,29 @@
+"""Data utilities for SPARK procedural experiments."""
+from .dataset import ProceduralDataset, ProceduralDatasetConfig
+from .instructions import (
+    InstructionSeedSet,
+    load_instruction_seed_set,
+    materialize_instructions,
+    save_instruction_seed_set,
+)
+from .statistics import (
+    METADATA_DIM,
+    DatasetStatistics,
+    deserialize_metadata_tensor,
+    metadata_from_tokens,
+    serialize_metadata_tensor,
+)
+
+__all__ = [
+    "METADATA_DIM",
+    "DatasetStatistics",
+    "ProceduralDataset",
+    "ProceduralDatasetConfig",
+    "InstructionSeedSet",
+    "materialize_instructions",
+    "save_instruction_seed_set",
+    "load_instruction_seed_set",
+    "metadata_from_tokens",
+    "serialize_metadata_tensor",
+    "deserialize_metadata_tensor",
+]

--- a/spark/data/dataset.py
+++ b/spark/data/dataset.py
@@ -1,0 +1,72 @@
+"""Synthetic data module emitting token, metadata and target tuples."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Optional, Tuple
+
+import torch
+
+from .statistics import DatasetStatistics, metadata_from_tokens
+
+
+@dataclass
+class ProceduralDatasetConfig:
+    vocab_size: int
+    sequence_length: int
+    batch_size: int
+    num_batches: Optional[int] = None
+    seed: int = 0
+    device: Optional[torch.device] = None
+
+
+class ProceduralDataset:
+    """Generates reproducible batches of tokens and metadata."""
+
+    def __init__(self, config: ProceduralDatasetConfig, preview_batches: int = 8) -> None:
+        self.config = config
+        self._device = config.device or torch.device("cpu")
+        self._seed = config.seed
+        self._preview_batches = max(preview_batches, 1)
+        self._statistics = self._bootstrap_statistics()
+
+    @property
+    def statistics(self) -> DatasetStatistics:
+        return self._statistics
+
+    def iter_batches(self, num_batches: Optional[int] = None) -> Iterator[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        limit = num_batches if num_batches is not None else self.config.num_batches
+        produced = 0
+        generator = torch.Generator(device=self._device).manual_seed(self._seed)
+        while limit is None or produced < limit:
+            tokens = torch.randint(
+                0,
+                self.config.vocab_size,
+                (self.config.batch_size, self.config.sequence_length),
+                generator=generator,
+                dtype=torch.int64,
+                device=self._device,
+            )
+            metadata = metadata_from_tokens(tokens, self.config.vocab_size)
+            targets = torch.roll(tokens, shifts=-1, dims=1)
+            produced += 1
+            yield tokens, metadata, targets
+
+    def _bootstrap_statistics(self) -> DatasetStatistics:
+        preview = []
+        generator = torch.Generator(device=self._device).manual_seed(self._seed)
+        for _ in range(self._preview_batches):
+            tokens = torch.randint(
+                0,
+                self.config.vocab_size,
+                (self.config.batch_size, self.config.sequence_length),
+                generator=generator,
+                dtype=torch.int64,
+            )
+            preview.append(tokens.cpu())
+        if not preview:
+            raise RuntimeError("Failed to materialize preview batches for statistics")
+        sample_tokens = torch.cat(preview, dim=0)
+        return DatasetStatistics.from_tokens(sample_tokens, self.config.vocab_size)
+
+
+__all__ = ["ProceduralDataset", "ProceduralDatasetConfig"]

--- a/spark/data/instructions.py
+++ b/spark/data/instructions.py
@@ -1,0 +1,108 @@
+"""Instruction seed management for deterministic decoding."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
+
+import torch
+
+from spark.demopack import DecodeInstruction
+
+from .statistics import DatasetStatistics
+
+PathLike = Union[str, Path]
+
+
+@dataclass
+class InstructionSeedSet:
+    """Container tracking per-layer instruction seeds."""
+
+    statistics: DatasetStatistics
+    seeds: List[int] = field(default_factory=list)
+    embedding: Optional[torch.Tensor] = None
+
+    @classmethod
+    def from_statistics(
+        cls,
+        statistics: DatasetStatistics,
+        num_layers: int,
+        embedding: Optional[torch.Tensor] = None,
+    ) -> "InstructionSeedSet":
+        seed_list = [statistics.seed_for_layer(i, embedding) for i in range(num_layers)]
+        return cls(statistics=statistics, seeds=seed_list, embedding=embedding)
+
+    def ensure_length(self, num_layers: int) -> None:
+        while len(self.seeds) < num_layers:
+            layer_index = len(self.seeds)
+            self.seeds.append(self.statistics.seed_for_layer(layer_index, self.embedding))
+
+    def to_dict(self) -> dict:
+        return {
+            "statistics": self.statistics.to_dict(),
+            "seeds": list(self.seeds),
+            "embedding": None
+            if self.embedding is None
+            else self.embedding.detach().cpu().tolist(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "InstructionSeedSet":
+        statistics = DatasetStatistics.from_dict(payload["statistics"])
+        embedding = payload.get("embedding")
+        tensor_embed = None
+        if embedding is not None:
+            tensor_embed = torch.tensor(embedding, dtype=torch.float32)
+        return cls(statistics=statistics, seeds=list(payload.get("seeds", [])), embedding=tensor_embed)
+
+
+def materialize_instructions(
+    seed_set: InstructionSeedSet,
+    num_layers: int,
+    tile_shape: Tuple[int, int],
+    codebook_size: int,
+    device: Optional[torch.device] = None,
+) -> List[DecodeInstruction]:
+    """Decode deterministic instruction tensors from ``seed_set``."""
+
+    seed_set.ensure_length(num_layers)
+    rows, cols = tile_shape
+    instructions: List[DecodeInstruction] = []
+    for layer_index in range(num_layers):
+        seed = seed_set.seeds[layer_index]
+        generator = torch.Generator(device=device).manual_seed(int(seed))
+        indices = torch.randint(
+            0,
+            codebook_size,
+            (rows, cols),
+            dtype=torch.int32,
+            generator=generator,
+            device=device,
+        )
+        instructions.append(DecodeInstruction(codeword_indices=indices, scale=1.0))
+    return instructions
+
+
+def save_instruction_seed_set(seed_set: InstructionSeedSet, path: PathLike) -> None:
+    """Persist ``seed_set`` to ``path`` as JSON."""
+
+    destination = Path(path)
+    payload = seed_set.to_dict()
+    destination.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def load_instruction_seed_set(path: PathLike) -> InstructionSeedSet:
+    """Load an :class:`InstructionSeedSet` from a JSON file."""
+
+    source = Path(path)
+    payload = json.loads(source.read_text())
+    return InstructionSeedSet.from_dict(payload)
+
+
+__all__ = [
+    "InstructionSeedSet",
+    "materialize_instructions",
+    "save_instruction_seed_set",
+    "load_instruction_seed_set",
+]

--- a/spark/data/statistics.py
+++ b/spark/data/statistics.py
@@ -1,0 +1,160 @@
+"""Dataset statistics and metadata utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+
+METADATA_DIM: int = 8
+
+
+def _normalize_divisor(value: int) -> float:
+    return float(value) if value else 1.0
+
+
+def metadata_from_tokens(tokens: torch.Tensor, vocab_size: int) -> torch.Tensor:
+    """Compute metadata features for each sequence in ``tokens``.
+
+    The returned tensor has ``METADATA_DIM`` features capturing distributional
+    properties of the batch that are useful for conditioning the
+    :class:`~spark.layer_generator.LayerGenerator` hypernetwork.
+    """
+
+    if tokens.ndim != 2:
+        raise ValueError("Expected rank-2 token tensor with shape (batch, seq_len)")
+    tokens_f = tokens.to(dtype=torch.float32)
+    batch, seq_len = tokens_f.shape
+    if seq_len == 0:
+        raise ValueError("Cannot compute metadata for empty sequences")
+    vmax = max(vocab_size - 1, 1)
+    mean = tokens_f.mean(dim=1)
+    std = tokens_f.std(dim=1, unbiased=False)
+    min_vals, _ = tokens_f.min(dim=1)
+    max_vals, _ = tokens_f.max(dim=1)
+    first_token = tokens_f[:, 0]
+    last_token = tokens_f[:, -1]
+    length = torch.full((batch,), float(seq_len), dtype=torch.float32, device=tokens_f.device)
+    unique_counts = torch.tensor(
+        [float(torch.unique(tokens[i]).numel()) for i in range(batch)],
+        dtype=torch.float32,
+        device=tokens_f.device,
+    )
+    metadata = torch.stack(
+        [
+            mean / vmax,
+            std / _normalize_divisor(vocab_size),
+            min_vals / vmax,
+            max_vals / vmax,
+            unique_counts / _normalize_divisor(vocab_size),
+            first_token / vmax,
+            last_token / vmax,
+            length / float(seq_len),
+        ],
+        dim=1,
+    )
+    return metadata
+
+
+@dataclass
+class DatasetStatistics:
+    """Summary statistics required for deterministic instruction seeds."""
+
+    vocab_size: int
+    sequence_length: int
+    summary: torch.Tensor
+
+    @classmethod
+    def from_tokens(cls, tokens: torch.Tensor, vocab_size: int) -> "DatasetStatistics":
+        if tokens.ndim != 2:
+            raise ValueError("Expected rank-2 tensor with shape (num_samples, seq_len)")
+        metadata = metadata_from_tokens(tokens, vocab_size)
+        summary = metadata.mean(dim=0)
+        return cls(vocab_size=vocab_size, sequence_length=tokens.size(1), summary=summary)
+
+    @classmethod
+    def synthetic(cls, vocab_size: int, sequence_length: int) -> "DatasetStatistics":
+        base = torch.arange(sequence_length, dtype=torch.int64)
+        samples = base.repeat(vocab_size, 1) % max(vocab_size, 1)
+        return cls.from_tokens(samples, vocab_size)
+
+    def to_metadata_tensor(self) -> torch.Tensor:
+        tensor = self.summary.detach().clone()
+        if tensor.numel() != METADATA_DIM:
+            raise ValueError(
+                f"Summary metadata must contain {METADATA_DIM} values, got {tensor.numel()}"
+            )
+        return tensor
+
+    def seed_for_layer(self, layer_index: int, embedding: Optional[torch.Tensor] = None) -> int:
+        """Derive a reproducible RNG seed for ``layer_index``.
+
+        The seed deterministically combines dataset statistics with an optional
+        embedding vector. This keeps procedural weight decoding reproducible
+        across training and inference runs.
+        """
+
+        if layer_index < 0:
+            raise ValueError("Layer index must be non-negative")
+        stats_vector = torch.cat(
+            [
+                torch.tensor(
+                    [float(self.vocab_size), float(self.sequence_length)],
+                    dtype=torch.float32,
+                )
+                / _normalize_divisor(self.vocab_size),
+                self.to_metadata_tensor(),
+            ]
+        )
+        if embedding is not None:
+            embed_vec = embedding.to(dtype=torch.float32).flatten()
+            stats_vector = torch.cat([stats_vector, embed_vec])
+        hash_value = torch.sum(stats_vector * (layer_index + 1) * 1000.0).item()
+        seed = int(abs(hash_value)) % (2**31 - 1)
+        if seed == 0:
+            seed = layer_index + 1
+        return seed
+
+    def to_dict(self) -> dict:
+        return {
+            "vocab_size": self.vocab_size,
+            "sequence_length": self.sequence_length,
+            "summary": self.summary.detach().cpu().tolist(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "DatasetStatistics":
+        summary = torch.tensor(payload["summary"], dtype=torch.float32)
+        return cls(
+            vocab_size=int(payload["vocab_size"]),
+            sequence_length=int(payload["sequence_length"]),
+            summary=summary,
+        )
+
+
+def serialize_metadata_tensor(metadata: torch.Tensor) -> dict:
+    """Serialize a metadata tensor to a portable dictionary."""
+
+    return {
+        "shape": list(metadata.shape),
+        "values": metadata.detach().cpu().tolist(),
+    }
+
+
+def deserialize_metadata_tensor(payload: dict, device: Optional[torch.device] = None) -> torch.Tensor:
+    """Inverse of :func:`serialize_metadata_tensor`."""
+
+    tensor = torch.tensor(payload["values"], dtype=torch.float32, device=device)
+    shape: Tuple[int, ...] = tuple(payload["shape"])
+    if int(torch.tensor(shape).prod().item()) != tensor.numel():
+        raise ValueError("Serialized metadata has inconsistent shape")
+    return tensor.view(*shape)
+
+
+__all__ = [
+    "DatasetStatistics",
+    "METADATA_DIM",
+    "metadata_from_tokens",
+    "serialize_metadata_tensor",
+    "deserialize_metadata_tensor",
+]

--- a/spark/demopack.py
+++ b/spark/demopack.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import torch
 
@@ -132,10 +132,57 @@ def build_random_instructions(
     return instructions
 
 
+def serialize_instruction(instruction: DecodeInstruction) -> dict:
+    """Serialize a single :class:`DecodeInstruction` into a portable dict."""
+
+    payload = {
+        "codeword_indices": instruction.codeword_indices.detach().cpu().tolist(),
+        "scale": float(instruction.scale),
+        "rotation": None,
+    }
+    if instruction.rotation is not None:
+        payload["rotation"] = instruction.rotation.detach().cpu().tolist()
+    return payload
+
+
+def deserialize_instruction(payload: dict, device: Optional[torch.device] = None) -> DecodeInstruction:
+    """Reconstruct a :class:`DecodeInstruction` from serialized data."""
+
+    indices = torch.tensor(payload["codeword_indices"], dtype=torch.int32, device=device)
+    rotation = payload.get("rotation")
+    rotation_tensor = None
+    if rotation is not None:
+        rotation_tensor = torch.tensor(rotation, dtype=torch.float32, device=device)
+    return DecodeInstruction(
+        codeword_indices=indices,
+        scale=float(payload.get("scale", 1.0)),
+        rotation=rotation_tensor,
+    )
+
+
+def serialize_instruction_set(instructions: Sequence[DecodeInstruction]) -> List[dict]:
+    """Serialize a sequence of instructions for persistence."""
+
+    return [serialize_instruction(inst) for inst in instructions]
+
+
+def deserialize_instruction_set(
+    payload: Sequence[dict],
+    device: Optional[torch.device] = None,
+) -> List[DecodeInstruction]:
+    """Inverse of :func:`serialize_instruction_set`."""
+
+    return [deserialize_instruction(item, device=device) for item in payload]
+
+
 __all__ = [
     "CodebookSpec",
     "DemopackCodebook",
     "DemopackDecoder",
     "DecodeInstruction",
     "build_random_instructions",
+    "serialize_instruction",
+    "deserialize_instruction",
+    "serialize_instruction_set",
+    "deserialize_instruction_set",
 ]

--- a/spark/hash_router.py
+++ b/spark/hash_router.py
@@ -13,16 +13,27 @@ def route_tokens(
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Select a sparse subset of neurons per token using random hashes."""
 
+    indices, _, compressed = route_tokens_with_metadata(
+        hidden, sparsity=sparsity, num_neurons=num_neurons
+    )
+    return indices, compressed
+
+
+def route_tokens_with_metadata(
+    hidden: torch.Tensor,
+    sparsity: float,
+    num_neurons: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Route tokens while also returning dispatch weights."""
+
     batch, seq_len, _ = hidden.shape
     num_active = max(1, int(num_neurons * sparsity))
     router_scores = torch.randn(batch, seq_len, num_neurons, device=hidden.device)
     topk = torch.topk(router_scores, num_active, dim=-1)
     indices = topk.indices
-    # Convert router scores into normalized dispatch weights for the selected
-    # neurons and broadcast the token representations to each active slot.
     weights = torch.softmax(topk.values, dim=-1)
     compressed = hidden.unsqueeze(-2) * weights.unsqueeze(-1)
-    return indices, compressed
+    return indices, weights, compressed
 
 
-__all__ = ["route_tokens"]
+__all__ = ["route_tokens", "route_tokens_with_metadata"]

--- a/spark/procedural_model.py
+++ b/spark/procedural_model.py
@@ -1,13 +1,21 @@
 """High-level integration of SPARK procedural components."""
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
-from .attention import AttentionBasisSynthesizer, AtomConfig
-from .demopack import CodebookSpec, DemopackCodebook, DemopackDecoder, build_random_instructions
+from .attention import AttentionBasisSynthesizer, AtomConfig, AttentionPatch
+from .data import (
+    METADATA_DIM,
+    DatasetStatistics,
+    InstructionSeedSet,
+    materialize_instructions,
+)
+from .demopack import CodebookSpec, DemopackCodebook, DemopackDecoder
+from .hash_router import route_tokens_with_metadata
 from .kv_patcher import KVCachePatcher
 from .layer_generator import GeneratorConfig, LayerGenerator, apply_lora_delta
 from .opcode_vm import Instruction, OpcodeVM
@@ -20,6 +28,13 @@ class ProceduralModelConfig:
     vocab_size: int
     codebook_spec: CodebookSpec
     generator_config: GeneratorConfig
+    dataset_statistics: Optional[DatasetStatistics] = None
+    instruction_seed_set: Optional[InstructionSeedSet] = None
+    attention_enabled: bool = True
+    routing_enabled: bool = True
+    kv_cache_enabled: bool = True
+    router_sparsity: float = 0.25
+    router_num_neurons: int = 64
 
 
 class ProceduralLanguageModel(torch.nn.Module):
@@ -29,10 +44,23 @@ class ProceduralLanguageModel(torch.nn.Module):
         super().__init__()
         self.config = config
         self.codebook = DemopackCodebook(config.codebook_spec)
-        tile_rows = 16
-        num_tiles = max(1, config.hidden_dim // tile_rows)
-        instructions = build_random_instructions(
-            num_tiles=num_tiles,
+        tile_rows = max(1, min(16, config.codebook_spec.embedding_dim))
+        num_tiles = max(1, math.ceil(config.hidden_dim / tile_rows))
+        self.dataset_statistics = config.dataset_statistics or DatasetStatistics.synthetic(
+            vocab_size=config.vocab_size,
+            sequence_length=config.input_dim,
+        )
+        if config.instruction_seed_set is not None:
+            self.instruction_seeds = config.instruction_seed_set
+            self.instruction_seeds.ensure_length(num_tiles)
+        else:
+            self.instruction_seeds = InstructionSeedSet.from_statistics(
+                self.dataset_statistics,
+                num_layers=num_tiles,
+            )
+        instructions = materialize_instructions(
+            seed_set=self.instruction_seeds,
+            num_layers=num_tiles,
             tile_shape=(tile_rows, config.input_dim),
             codebook_size=config.codebook_spec.num_codewords,
         )
@@ -42,8 +70,13 @@ class ProceduralLanguageModel(torch.nn.Module):
             in_features=config.input_dim,
             instructions=instructions,
         )
-        self.generator = LayerGenerator(config.generator_config, metadata_dim=8)
+        self.generator = LayerGenerator(config.generator_config, metadata_dim=METADATA_DIM)
         self.lm_head = torch.nn.Linear(num_tiles * tile_rows, config.vocab_size)
+        self.token_proj = torch.nn.Linear(config.input_dim, config.hidden_dim)
+        self.query_proj = torch.nn.Linear(config.hidden_dim, config.hidden_dim)
+        self.key_proj = torch.nn.Linear(config.hidden_dim, config.hidden_dim)
+        self.value_proj = torch.nn.Linear(config.hidden_dim, config.hidden_dim)
+        self.attn_output_proj = torch.nn.Linear(config.hidden_dim, config.input_dim)
         atom_cfgs = [
             AtomConfig(name="sin", frequency=freq) for freq in (1.0, 2.0, 4.0)
         ] + [
@@ -52,9 +85,75 @@ class ProceduralLanguageModel(torch.nn.Module):
         self.attention = AttentionBasisSynthesizer(atom_cfgs, max_length=1024)
         self.kv_patcher = KVCachePatcher()
         self.vm = OpcodeVM()
+        self.latest_routing_metadata: List[Optional[Dict[str, torch.Tensor]]] = []
 
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        hidden = self.decoder(inputs)
+        if inputs.ndim == 2:
+            inputs = inputs.unsqueeze(1)
+        elif inputs.ndim != 3:
+            raise ValueError("Inputs must be rank-2 or rank-3 tensor")
+
+        _, seq_len, _ = inputs.shape
+        device = inputs.device
+
+        tokens = self.token_proj(inputs)
+        queries = self.query_proj(tokens)
+        keys = self.key_proj(tokens)
+        values = self.value_proj(tokens)
+
+        decoder_inputs: List[torch.Tensor] = []
+        routing_metadata: List[Optional[Dict[str, torch.Tensor]]] = []
+
+        for step in range(seq_len):
+            query = queries[:, step : step + 1, :]
+            if self.config.kv_cache_enabled:
+                segment_id = step
+                self.kv_patcher.mark(segment_id)
+                try:
+                    cached_keys, cached_values = self.kv_patcher.gather([segment_id])
+                except KeyError:
+                    cached_keys = keys[:, : step + 1, :]
+                    cached_values = values[:, : step + 1, :]
+                else:
+                    if cached_keys.size(1) < step + 1:
+                        new_keys = keys[:, cached_keys.size(1) : step + 1, :]
+                        new_values = values[:, cached_keys.size(1) : step + 1, :]
+                        cached_keys = torch.cat([cached_keys, new_keys], dim=1)
+                        cached_values = torch.cat([cached_values, new_values], dim=1)
+                self.kv_patcher.update(segment_id, cached_keys, cached_values)
+            else:
+                cached_keys = keys[:, : step + 1, :]
+                cached_values = values[:, : step + 1, :]
+
+            if self.config.attention_enabled:
+                patch = self._build_attention_patch(query.size(1), device)
+                attn_out = self.attention.apply_attention(
+                    patch, query, cached_keys, cached_values
+                )
+            else:
+                attn_out = query
+
+            if self.config.routing_enabled:
+                sparse, dense, metadata = self._compile_routing_metadata(attn_out)
+                combined = sparse.sum(dim=-2)
+                fallback = dense.squeeze(1)
+                combined = combined.squeeze(1)
+                combined = combined + (fallback - fallback.detach())
+                routing_metadata.append(metadata)
+            else:
+                combined = attn_out.squeeze(1)
+                routing_metadata.append(None)
+
+            decoder_inputs.append(self.attn_output_proj(combined))
+
+        if self.config.kv_cache_enabled:
+            self.kv_patcher.sweep()
+
+        self.latest_routing_metadata = routing_metadata
+
+        stacked = torch.stack(decoder_inputs, dim=1)
+        decoder_input = stacked.mean(dim=1)
+        hidden = self.decoder(decoder_input)
         logits = self.lm_head(hidden)
         return logits
 
@@ -67,6 +166,26 @@ class ProceduralLanguageModel(torch.nn.Module):
     def reason(self, instructions: List[Instruction]) -> List[str]:
         state = self.vm.execute(instructions)
         return state.log
+
+    def _build_attention_patch(self, seq_len: int, device: torch.device) -> AttentionPatch:
+        atom_indices = torch.arange(len(self.attention.atoms), device=device, dtype=torch.long)
+        gains = torch.ones(atom_indices.size(0), device=device, dtype=torch.float32)
+        shifts = torch.zeros_like(atom_indices)
+        window = torch.ones(seq_len, device=device, dtype=torch.float32)
+        return AttentionPatch(atom_indices=atom_indices, gains=gains, shifts=shifts, window=window)
+
+    def _compile_routing_metadata(
+        self, hidden: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, torch.Tensor]]:
+        sparsity = self.config.router_sparsity
+        num_neurons = self.config.router_num_neurons
+        indices, weights, compressed = route_tokens_with_metadata(
+            hidden,
+            sparsity=sparsity,
+            num_neurons=num_neurons,
+        )
+        metadata: Dict[str, torch.Tensor] = {"indices": indices, "weights": weights}
+        return compressed, hidden, metadata
 
 
 __all__ = ["ProceduralModelConfig", "ProceduralLanguageModel"]

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -1,0 +1,92 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from spark.data import (
+    METADATA_DIM,
+    DatasetStatistics,
+    InstructionSeedSet,
+    ProceduralDataset,
+    ProceduralDatasetConfig,
+    deserialize_metadata_tensor,
+    load_instruction_seed_set,
+    materialize_instructions,
+    save_instruction_seed_set,
+    serialize_metadata_tensor,
+)
+from spark.demopack import deserialize_instruction_set, serialize_instruction_set
+
+
+def test_procedural_dataset_emits_expected_shapes():
+    config = ProceduralDatasetConfig(
+        vocab_size=32,
+        sequence_length=12,
+        batch_size=4,
+        num_batches=2,
+        seed=123,
+    )
+    dataset = ProceduralDataset(config)
+    batch = next(dataset.iter_batches(num_batches=1))
+    tokens, metadata, targets = batch
+    assert tokens.shape == (4, 12)
+    assert metadata.shape == (4, METADATA_DIM)
+    assert targets.shape == (4, 12)
+    dataset_again = ProceduralDataset(config)
+    tokens_b, metadata_b, targets_b = next(dataset_again.iter_batches(num_batches=1))
+    assert torch.equal(tokens, tokens_b)
+    assert torch.allclose(metadata, metadata_b)
+    assert torch.equal(targets, targets_b)
+
+
+def test_instruction_seed_set_materialization_roundtrip(tmp_path):
+    config = ProceduralDatasetConfig(vocab_size=48, sequence_length=6, batch_size=2, seed=7)
+    dataset = ProceduralDataset(config)
+    stats = dataset.statistics
+    seed_set = InstructionSeedSet.from_statistics(stats, num_layers=3)
+    payload = seed_set.to_dict()
+    restored = InstructionSeedSet.from_dict(payload)
+    path = tmp_path / "seeds.json"
+    save_instruction_seed_set(restored, path)
+    restored = load_instruction_seed_set(path)
+    instructions = materialize_instructions(
+        seed_set=restored,
+        num_layers=3,
+        tile_shape=(2, config.sequence_length),
+        codebook_size=config.vocab_size,
+    )
+    instructions_again = materialize_instructions(
+        seed_set=restored,
+        num_layers=3,
+        tile_shape=(2, config.sequence_length),
+        codebook_size=config.vocab_size,
+    )
+    for inst_a, inst_b in zip(instructions, instructions_again):
+        assert torch.equal(inst_a.codeword_indices, inst_b.codeword_indices)
+        assert inst_a.scale == pytest.approx(inst_b.scale)
+
+
+def test_instruction_and_metadata_serialization():
+    config = ProceduralDatasetConfig(vocab_size=16, sequence_length=8, batch_size=3, seed=99)
+    dataset = ProceduralDataset(config)
+    tokens, metadata, _ = next(dataset.iter_batches(num_batches=1))
+    seed_set = InstructionSeedSet.from_statistics(dataset.statistics, num_layers=2)
+    instructions = materialize_instructions(
+        seed_set=seed_set,
+        num_layers=2,
+        tile_shape=(2, config.sequence_length),
+        codebook_size=config.vocab_size,
+    )
+    serialized_instructions = serialize_instruction_set(instructions)
+    restored_instructions = deserialize_instruction_set(serialized_instructions)
+    for inst_original, inst_restored in zip(instructions, restored_instructions):
+        assert torch.equal(inst_original.codeword_indices, inst_restored.codeword_indices)
+        assert inst_original.scale == pytest.approx(inst_restored.scale)
+        if inst_original.rotation is None:
+            assert inst_restored.rotation is None
+    serialized_metadata = serialize_metadata_tensor(metadata)
+    restored_metadata = deserialize_metadata_tensor(serialized_metadata)
+    assert restored_metadata.shape == metadata.shape
+    assert torch.allclose(restored_metadata, metadata)
+    stats_payload = dataset.statistics.to_dict()
+    restored_stats = DatasetStatistics.from_dict(stats_payload)
+    assert torch.allclose(restored_stats.to_metadata_tensor(), dataset.statistics.to_metadata_tensor())

--- a/tests/test_demopack.py
+++ b/tests/test_demopack.py
@@ -2,13 +2,21 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from spark.demopack import CodebookSpec, DemopackCodebook, DemopackDecoder, build_random_instructions
+from spark.data import DatasetStatistics, InstructionSeedSet, materialize_instructions
+from spark.demopack import CodebookSpec, DemopackCodebook, DemopackDecoder
 
 
 def test_demopack_decode_matches_linear():
     spec = CodebookSpec(num_codewords=16, embedding_dim=8)
     codebook = DemopackCodebook(spec)
-    instructions = build_random_instructions(4, (4, 8), spec.num_codewords)
+    stats = DatasetStatistics.synthetic(vocab_size=spec.num_codewords, sequence_length=8)
+    seed_set = InstructionSeedSet.from_statistics(stats, num_layers=4)
+    instructions = materialize_instructions(
+        seed_set=seed_set,
+        num_layers=4,
+        tile_shape=(4, 8),
+        codebook_size=spec.num_codewords,
+    )
     layer = DemopackDecoder(codebook, out_features=16, in_features=8, instructions=instructions)
     x = torch.randn(2, 8)
     out = layer(x)


### PR DESCRIPTION
## Summary
- reinstate the attention, routing, and kv cache features in the procedural model while wiring them to deterministic decoder instructions from the data module
- expose routing configuration options on the procedural model config and track emitted metadata for downstream inspection
- extend the hash router to provide dispatch weights alongside indices so procedural decoding can capture routing metadata
- add JSON persistence helpers for instruction seed sets so deterministic decoder configurations can be saved and reloaded

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db107d4590832a8506e923a394ae4d