### PR TITLE
Add training command to SPARK CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,25 @@ pytest
 ```
 
 A consolidated CLI is available via ``python -m spark``.  It exposes utilities
-for automated evaluation and a lightweight chat demonstration:
+for automated evaluation, a lightweight chat demonstration, and a training
+workflow that produces checkpoints with learnable generator weights:
 
 ```powershell
 # Run a single evaluation sweep and emit JSON metrics
 python -m spark eval --batch-size 8 --runs 3 --output results.json
 
+# Train the procedural model on synthetic data and save metrics
+python -m spark train --epochs 2 --steps-per-epoch 50 --output training.json
+
 # Launch the interactive chat demo (type /exit to quit)
 python -m spark chat --show-trace
 ```
+
+The training command accepts the same architectural hyper-parameters as the
+other subcommands along with optimiser knobs such as ``--learning-rate`` and
+``--grad-clip``.  Custom experiment configurations can also be supplied as JSON
+via ``--config``; each run emits a JSON summary describing the device, losses
+per epoch, and final checkpoint location.
 
 A quick interactive demo can be executed with Python:
 

--- a/spark/cli.py
+++ b/spark/cli.py
@@ -32,6 +32,7 @@ from .evaluation import EvaluationBatch, build_dense_baseline, compare_models
 from .layer_generator import GeneratorConfig
 from .opcode_vm import Instruction, Opcode
 from .procedural_model import ProceduralLanguageModel, ProceduralModelConfig
+from .training import TrainingConfig, TrainingEpochReport, run_training
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +67,20 @@ def _build_model_config(cfg: ModelCLIConfig) -> ProceduralModelConfig:
         vocab_size=cfg.vocab_size,
         codebook_spec=codebook_spec,
         generator_config=generator_cfg,
+        metadata_dim=cfg.metadata_dim,
+        codebook_learnable=cfg.codebook_learnable,
+    )
+
+
+def _model_config_from_training(cfg: TrainingConfig) -> ModelCLIConfig:
+    return ModelCLIConfig(
+        input_dim=cfg.input_dim,
+        hidden_dim=cfg.hidden_dim,
+        vocab_size=cfg.vocab_size,
+        codebook_size=cfg.codebook_size,
+        generator_embed_dim=cfg.generator_embed_dim,
+        generator_hidden_dim=cfg.generator_hidden_dim,
+        generator_rank=cfg.generator_rank,
         metadata_dim=cfg.metadata_dim,
         codebook_learnable=cfg.codebook_learnable,
     )
@@ -124,6 +139,18 @@ def _aggregate_metrics(reports: List[dict]) -> dict:
     return summary
 
 
+def _load_training_config(path: Optional[str]) -> TrainingConfig:
+    if path is None:
+        return TrainingConfig()
+    payload = json.loads(Path(path).read_text())
+    return TrainingConfig(**payload)
+
+
+def _apply_override(cfg: TrainingConfig, field: str, value: Optional[int | float | str | bool]) -> None:
+    if value is not None:
+        setattr(cfg, field, value)
+
+
 def run_eval_command(args: argparse.Namespace) -> int:
     device = _device_from_args(args.device)
     _set_seed(args.seed, device)
@@ -173,6 +200,58 @@ def run_eval_command(args: argparse.Namespace) -> int:
         output_path.write_text(json.dumps(payload, indent=2))
 
     print(json.dumps(payload, indent=2))
+    return 0
+
+
+def run_train_command(args: argparse.Namespace) -> int:
+    device = _device_from_args(args.device)
+    cfg = _load_training_config(args.config)
+
+    _apply_override(cfg, "input_dim", args.input_dim)
+    _apply_override(cfg, "hidden_dim", args.hidden_dim)
+    _apply_override(cfg, "vocab_size", args.vocab_size)
+    _apply_override(cfg, "codebook_size", args.codebook_size)
+    _apply_override(cfg, "generator_embed_dim", args.generator_embed_dim)
+    _apply_override(cfg, "generator_hidden_dim", args.generator_hidden_dim)
+    _apply_override(cfg, "generator_rank", args.generator_rank)
+    _apply_override(cfg, "metadata_dim", args.metadata_dim)
+    if args.codebook_learnable is not None:
+        cfg.codebook_learnable = bool(args.codebook_learnable)
+    _apply_override(cfg, "batch_size", args.batch_size)
+    _apply_override(cfg, "epochs", args.epochs)
+    _apply_override(cfg, "steps_per_epoch", args.steps_per_epoch)
+    _apply_override(cfg, "eval_steps", args.eval_steps)
+    if args.learning_rate is not None:
+        cfg.learning_rate = args.learning_rate
+    if args.weight_decay is not None:
+        cfg.weight_decay = args.weight_decay
+    if args.grad_clip is not None:
+        cfg.grad_clip = args.grad_clip
+    if args.seed is not None:
+        cfg.seed = args.seed
+    if args.use_amp is not None:
+        cfg.use_amp = bool(args.use_amp)
+    if args.checkpoint_dir is not None:
+        cfg.checkpoint_dir = args.checkpoint_dir
+    if args.resume is not None:
+        cfg.resume_from = args.resume
+
+    total_epochs = cfg.epochs
+
+    def _log_progress(report: TrainingEpochReport) -> None:
+        print(
+            f"Epoch {report.epoch}/{total_epochs} - train_loss: {report.train_loss:.4f} - eval_loss: {report.eval_loss:.4f}",
+            flush=True,
+        )
+
+    summary = run_training(cfg, device=device, progress_callback=_log_progress)
+
+    if args.output is not None:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(summary, indent=2))
+
+    print(json.dumps(summary, indent=2))
     return 0
 
 
@@ -288,26 +367,49 @@ def run_chat_command(args: argparse.Namespace) -> int:
 # Argument parsing
 
 
-def _add_model_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--input-dim", type=int, default=32, help="Dimension of model inputs")
-    parser.add_argument("--hidden-dim", type=int, default=64, help="Hidden size of the model")
-    parser.add_argument("--vocab-size", type=int, default=320, help="Vocabulary size for logits")
-    parser.add_argument("--codebook-size", type=int, default=128, help="Number of codebook entries")
-    parser.add_argument(
-        "--generator-embed-dim", type=int, default=32, help="Generator embedding dimension"
+def _model_default(value: ModelCLIConfig | None, field: str, fallback: int) -> int:
+    return getattr(value, field) if value is not None else fallback
+
+
+def _bool_default(value: ModelCLIConfig | None, field: str, fallback: bool) -> bool:
+    return getattr(value, field) if value is not None else fallback
+
+
+def _add_model_arguments(
+    parser: argparse.ArgumentParser,
+    defaults: ModelCLIConfig | None = None,
+    *,
+    as_overrides: bool = False,
+) -> None:
+    def numeric_argument(name: str, field: str, fallback: int, help_text: str) -> None:
+        default_value = None if as_overrides else _model_default(defaults, field, fallback)
+        extra = f" (default: {_model_default(defaults, field, fallback)})" if as_overrides else ""
+        parser.add_argument(name, type=int, default=default_value, help=help_text + extra)
+
+    numeric_argument("--input-dim", "input_dim", 32, "Dimension of model inputs")
+    numeric_argument("--hidden-dim", "hidden_dim", 64, "Hidden size of the model")
+    numeric_argument("--vocab-size", "vocab_size", 320, "Vocabulary size for logits")
+    numeric_argument("--codebook-size", "codebook_size", 128, "Number of codebook entries")
+    numeric_argument("--generator-embed-dim", "generator_embed_dim", 32, "Generator embedding dimension")
+    numeric_argument("--generator-hidden-dim", "generator_hidden_dim", 64, "Generator hidden dimension")
+    numeric_argument("--generator-rank", "generator_rank", 4, "Generator low-rank size")
+    numeric_argument("--metadata-dim", "metadata_dim", 16, "Metadata vector dimension")
+
+    bool_default = None if as_overrides else _bool_default(defaults, "codebook_learnable", False)
+    bool_extra = (
+        f" (default: {_bool_default(defaults, 'codebook_learnable', False)})" if as_overrides else ""
     )
-    parser.add_argument(
-        "--generator-hidden-dim", type=int, default=64, help="Generator hidden dimension"
-    )
-    parser.add_argument("--generator-rank", type=int, default=4, help="Generator low-rank size")
-    parser.add_argument("--metadata-dim", type=int, default=16, help="Metadata vector dimension")
     parser.add_argument(
         "--codebook-learnable",
-        action="store_true",
-        help="Promote the codebook to a learnable parameter",
+        action=argparse.BooleanOptionalAction,
+        default=bool_default,
+        help="Promote the codebook to a learnable parameter" + bool_extra,
     )
-    parser.add_argument("--device", type=str, default=None, help="Device to run on (cpu/cuda)")
-    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    device_default = None if as_overrides else None
+    parser.add_argument("--device", type=str, default=device_default, help="Device to run on (cpu/cuda)")
+    seed_default = None if as_overrides else 42
+    seed_extra = " (default: 42)" if as_overrides else ""
+    parser.add_argument("--seed", type=int, default=seed_default, help="Random seed" + seed_extra)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -337,6 +439,81 @@ def _build_parser() -> argparse.ArgumentParser:
         "--max-turns", type=int, default=None, help="Maximum number of turns before exit"
     )
     chat_parser.set_defaults(func=run_chat_command)
+
+    training_defaults = TrainingConfig()
+    train_parser = subparsers.add_parser("train", help="Run a training experiment")
+    train_parser.add_argument(
+        "--config", type=str, default=None, help="Optional JSON config containing TrainingConfig fields"
+    )
+    train_parser.add_argument(
+        "--resume",
+        type=str,
+        default=None,
+        help="Resume from a checkpoint path produced by a previous training run",
+    )
+    train_parser.add_argument(
+        "--output", type=str, default=None, help="Optional JSON file to store the training summary"
+    )
+    _add_model_arguments(
+        train_parser,
+        defaults=_model_config_from_training(training_defaults),
+        as_overrides=True,
+    )
+    train_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help=f"Mini-batch size (default: {training_defaults.batch_size})",
+    )
+    train_parser.add_argument(
+        "--epochs",
+        type=int,
+        default=None,
+        help=f"Number of epochs to train (default: {training_defaults.epochs})",
+    )
+    train_parser.add_argument(
+        "--steps-per-epoch",
+        type=int,
+        default=None,
+        help=f"Synthetic steps per epoch (default: {training_defaults.steps_per_epoch})",
+    )
+    train_parser.add_argument(
+        "--eval-steps",
+        type=int,
+        default=None,
+        help=f"Number of evaluation steps (default: {training_defaults.eval_steps})",
+    )
+    train_parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=None,
+        help=f"Optimizer learning rate (default: {training_defaults.learning_rate})",
+    )
+    train_parser.add_argument(
+        "--weight-decay",
+        type=float,
+        default=None,
+        help=f"Optimizer weight decay (default: {training_defaults.weight_decay})",
+    )
+    train_parser.add_argument(
+        "--grad-clip",
+        type=float,
+        default=None,
+        help=f"Gradient clipping value (default: {training_defaults.grad_clip})",
+    )
+    train_parser.add_argument(
+        "--use-amp",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=f"Enable automatic mixed precision (default: {training_defaults.use_amp})",
+    )
+    train_parser.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        default=None,
+        help=f"Directory to store checkpoints (default: {training_defaults.checkpoint_dir})",
+    )
+    train_parser.set_defaults(func=run_train_command)
 
     return parser
 

--- a/spark/training/__init__.py
+++ b/spark/training/__init__.py
@@ -1,5 +1,5 @@
 """Training utilities for the SPARK procedural language model."""
 
-from .train import main
+from .train import TrainingConfig, TrainingEpochReport, main, run_training
 
-__all__ = ["main"]
+__all__ = ["main", "run_training", "TrainingConfig", "TrainingEpochReport"]


### PR DESCRIPTION
## Summary
- add a `spark train` subcommand that wraps the training utilities with configurable hyper-parameters and JSON summaries
- refactor the training entry point into a reusable `run_training` helper, add safety checks for generator deltas, and expose the API from the package
- document the new training workflow in the README and update defaults for generator embeddings

## Testing
- pytest
- python -m spark train --epochs 1 --steps-per-epoch 1 --eval-steps 1 --batch-size 2 --device cpu --output tmp_training.json


------
https://chatgpt.com/codex/tasks/task_e_68db21075a5c832aafbb394b4c6e44f0